### PR TITLE
Fix bugs in h5manager and OpenSlideBackend

### DIFF
--- a/pathml/core/h5managers.py
+++ b/pathml/core/h5managers.py
@@ -3,17 +3,17 @@ Copyright 2021, Dana-Farber Cancer Institute and Weill Cornell Medicine
 License: GNU GPL 2.0
 """
 
-import h5py
+import itertools
+import os
 import tempfile
 from collections import OrderedDict
-import numpy as np
-import itertools
-import anndata
-import os
 
+import anndata
+import h5py
+import numpy as np
+import pathml.core
 import pathml.core.masks
 import pathml.core.tile
-import pathml.core
 from pathml.core.utils import readcounts
 
 
@@ -132,7 +132,8 @@ class h5pathManager:
                 for coord, tile_shape in zip(coords, tile.image.shape[0:coordslength])
             ]
             for dim, (current, required) in enumerate(zip(currentshape, requiredshape)):
-                self.h5["array"].resize(required, axis=dim)
+                if current < required:
+                    self.h5["array"].resize(required, axis=dim)
 
             # add tile to self.h5["array"]
             slicer = [
@@ -192,7 +193,8 @@ class h5pathManager:
                     for dim, (current, required) in enumerate(
                         zip(currentshape, requiredshape)
                     ):
-                        self.h5["masks"][mask].resize(required, axis=dim)
+                        if current < required:
+                            self.h5["masks"][mask].resize(required, axis=dim)
 
                     # add mask to mask array
                     slicer = [

--- a/pathml/core/slide_backends.py
+++ b/pathml/core/slide_backends.py
@@ -72,7 +72,7 @@ class OpenSlideBackend(SlideBackend):
         Extract a region of the image
 
         Args:
-            location (Tuple[int, int]): Location of top-left corner of tile
+            location (Tuple[int, int]): Location of top-left corner of tile (i, j)
             size (Union[int, Tuple[int, int]]): Size of each tile. May be a tuple of (height, width) or a
                 single integer, in which case square tiles of that size are generated.
             level (int): level from which to extract chunks. Level 0 is highest resolution.
@@ -96,8 +96,10 @@ class OpenSlideBackend(SlideBackend):
             assert (
                 level < self.slide.level_count
             ), f"input level {level} invalid for a slide with {self.slide.level_count} levels"
-
-        region = self.slide.read_region(location=location, level=level, size=size)
+        # openslide read_region expects (x, y) coords, so need to switch order for compatibility with pathml (i, j)
+        i, j = location
+        h, w = size
+        region = self.slide.read_region(location=(j, i), level=level, size=(w, h))
         region_rgb = pil_to_rgb(region)
         return region_rgb
 
@@ -109,7 +111,7 @@ class OpenSlideBackend(SlideBackend):
             level (int): Which level to get shape from. Level 0 is highest resolution. Defaults to 0.
 
         Returns:
-            Tuple[int, int]: Shape of image at target level.
+            Tuple[int, int]: Shape of image at target level, in (i, j) coordinates.
         """
         assert isinstance(level, int), f"level {level} invalid. Must be an int."
         assert (

--- a/tests/core_tests/test_h5managers.py
+++ b/tests/core_tests/test_h5managers.py
@@ -2,3 +2,42 @@
 Copyright 2021, Dana-Farber Cancer Institute and Weill Cornell Medicine
 License: GNU GPL 2.0
 """
+
+import copy
+
+import numpy as np
+import pytest
+from pathml.core import HESlide
+from pathml.core.h5managers import h5pathManager
+from pathml.core.tiles import Tiles
+from pathml.preprocessing.pipeline import Pipeline
+
+
+def test_h5manager(example_slide_data):
+    """
+    See issue #181.
+    """
+    pipe = Pipeline([])
+    example_slide_data.run(pipe, distributed=False, tile_size=200)
+    for tile in example_slide_data.tiles:
+        assert np.count_nonzero(tile.image) > 0
+
+
+def test_h5manager2(tileHE):
+    slidedata1 = HESlide("tests/testdata/small_HE.svs")
+    slidedata2 = HESlide("tests/testdata/small_HE.svs")
+    tiles1 = slidedata1.tiles
+    tiles2 = slidedata2.tiles
+    coordslist = [(0, 0), (0, 500), (0, 0)]
+    for coord in coordslist[0:2]:
+        tile = copy.deepcopy(tileHE)
+        tile.coords = coord
+        tiles1.add(tile)
+
+    for coord in coordslist:
+        tile = copy.deepcopy(tileHE)
+        tile.coords = coord
+        tiles2.add(tile)
+
+    for tile1, tile2 in zip(tiles1, tiles2):
+        np.testing.assert_array_equal(tile1.image, tile2.image)


### PR DESCRIPTION
This PR fixes two bugs, one or both of which was causing #181

1. When a tile is added to h5, and the h5 array is resized to accomodate it, added a check to make sure that we only make the h5 array bigger (instead of resizing it to make it smaller, losing data)
2. In `OpenSlideBackend.extract_region()`, the `location` and `size` arguments are in (i, j) coordinates, which is consistent with the rest of PathML, NumPy, etc. However, Openslide uses (x, y) coordinates, and I had overlooked that we need to flip the order before calling the openslide function. Fixed this.