### PR TITLE
Fix continuous integration configuration

### DIFF
--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -2,7 +2,13 @@ name: Tests
 
 on: 
   pull_request:
-    branches: [dev, master]
+    branches:
+      - dev
+      - master
+  push:
+    branches:
+      - dev
+      - master
 
 jobs:
   build-linux:


### PR DESCRIPTION
This changes the CI suite to be triggered not only on pull requests, but also on pushes. 

Currently, when a PR is opened to merge branch A into dev, the CI suite is run on branch A (triggered by pull request) but when we merge it into dev, the CI suite is not actually run on the newly updated dev branch. This is causing #201, #168, and also some problems with codecoverage integration. Hopefully this will fix those by triggering the CI suite on push events (i.e., after merging has occurred).