### PR TITLE
Fix ci

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,9 +1,6 @@
 name: Publish PathML distribution to PyPI and TestPyPI
 
 on:
-  push:
-    tags: ['v*']
-    branches: [master]
   release:
     types: [published]
 

--- a/pathml/_version.py
+++ b/pathml/_version.py
@@ -3,4 +3,4 @@ Copyright 2021, Dana-Farber Cancer Institute and Weill Cornell Medicine
 License: GNU GPL 2.0
 """
 
-__version__ = "1.0.5"
+__version__ = "1.0.dev3"

--- a/pathml/_version.py
+++ b/pathml/_version.py
@@ -3,4 +3,4 @@ Copyright 2021, Dana-Farber Cancer Institute and Weill Cornell Medicine
 License: GNU GPL 2.0
 """
 
-__version__ = "1.0.dev3"
+__version__ = "1.0.dev4"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -8,5 +8,38 @@ import pathml
 
 
 def test_version_format():
-    # semantic versioning format: major.minor.patch
-    assert re.match("^[\d]+.[\d]+.[\d]+$", pathml.__version__)
+    # regex to check that version specification complies with PEP440
+    # This regex pattern copied directly from pypa:
+    # https://github.com/pypa/packaging/blob/b5f0efdf3986725c2a45437e03d0ee5939c21192/packaging/version.py#L159-L188
+    VERSION_PATTERN = r"""
+        v?
+        (?:
+            (?:(?P<epoch>[0-9]+)!)?                           # epoch
+            (?P<release>[0-9]+(?:\.[0-9]+)*)                  # release segment
+            (?P<pre>                                          # pre-release
+                [-_\.]?
+                (?P<pre_l>(a|b|c|rc|alpha|beta|pre|preview))
+                [-_\.]?
+                (?P<pre_n>[0-9]+)?
+            )?
+            (?P<post>                                         # post release
+                (?:-(?P<post_n1>[0-9]+))
+                |
+                (?:
+                    [-_\.]?
+                    (?P<post_l>post|rev|r)
+                    [-_\.]?
+                    (?P<post_n2>[0-9]+)?
+                )
+            )?
+            (?P<dev>                                          # dev release
+                [-_\.]?
+                (?P<dev_l>dev)
+                [-_\.]?
+                (?P<dev_n>[0-9]+)?
+            )?
+        )
+        (?:\+(?P<local>[a-z0-9]+(?:[-_\.][a-z0-9]+)*))?       # local version
+    """
+    _regex = re.compile(VERSION_PATTERN, re.VERBOSE | re.IGNORECASE)
+    assert _regex.search(pathml.__version__)


### PR DESCRIPTION
Only trigger PyPI publication action when we create a new release.
Update version checking regex to match PEP440.