### PR TITLE
avoid log4j

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setuptools.setup(
         "scanpy",
         "torch",
         "opencv-contrib-python",
-        "python-bioformats",
+        "python-bioformats>=4.0.0",
     ],
     classifiers=[
         "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",


### PR DESCRIPTION
Pin bioformats version to ensure that we aren't vulnerable to [log4j](https://logging.apache.org/log4j/2.x/security.html) hacks

Any bioformats version since v4.0.0 and should be safe (https://github.com/CellProfiler/python-bioformats/issues/152)

Thanks for pointing this out @dmbrundage 
