### PR TITLE
Improve h5path read/write

### DIFF
--- a/pathml/_version.py
+++ b/pathml/_version.py
@@ -3,4 +3,4 @@ Copyright 2021, Dana-Farber Cancer Institute and Weill Cornell Medicine
 License: GNU GPL 2.0
 """
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"

--- a/pathml/core/h5managers.py
+++ b/pathml/core/h5managers.py
@@ -155,9 +155,7 @@ class h5pathManager:
             # add tile-level masks
             for key, mask in tile.masks.items():
                 self.h5["tiles"][str(tile.coords)]["masks"].create_dataset(
-                    str(key),
-                    data=mask,
-                    dtype="float16",
+                    str(key), data=mask, dtype="float16",
                 )
 
         # add coords
@@ -177,6 +175,7 @@ class h5pathManager:
             if self.counts:
                 self.counts = self.counts.to_memory()
                 self.counts = self.counts.concatenate(tile.counts, join="outer")
+                del self.counts.obs["batch"]
                 self.counts.filename = os.path.join(
                     self.countspath.name + "/tmpfile.h5ad"
                 )

--- a/pathml/core/utils.py
+++ b/pathml/core/utils.py
@@ -110,8 +110,10 @@ def readcounts(h5):
     # create and save temp h5py file
     # read using anndata from temp file
     # anndata does not support reading directly from h5
-    path = tempfile.NamedTemporaryFile()
-    f = h5py.File(path, "w")
-    for ds in h5.keys():
-        h5.copy(ds, f)
-    return anndata.read_h5ad(path.name)
+    with tempfile.NamedTemporaryFile() as path:
+        with h5py.File(path, "w") as f:
+            for ds in h5.keys():
+                h5.copy(ds, f)
+        print(path)
+        print(path.name)
+        return anndata.read_h5ad(path.name)

--- a/pathml/core/utils.py
+++ b/pathml/core/utils.py
@@ -114,6 +114,4 @@ def readcounts(h5):
         with h5py.File(path, "w") as f:
             for ds in h5.keys():
                 h5.copy(ds, f)
-        print(path)
-        print(path.name)
         return anndata.read_h5ad(path.name)

--- a/pathml/preprocessing/transforms.py
+++ b/pathml/preprocessing/transforms.py
@@ -13,15 +13,11 @@ import pandas as pd
 import pathml.core
 import pathml.core.slide_data
 import spams
-from pathml.utils import (
-    RGB_to_GREY,
-    RGB_to_HSI,
-    RGB_to_HSV,
-    RGB_to_OD,
-    normalize_matrix_cols,
-)
+from pathml.utils import (RGB_to_GREY, RGB_to_HSI, RGB_to_HSV, RGB_to_OD,
+                          normalize_matrix_cols)
 from skimage import restoration
-from skimage.exposure import equalize_adapthist, equalize_hist, rescale_intensity
+from skimage.exposure import (equalize_adapthist, equalize_hist,
+                              rescale_intensity)
 from skimage.measure import regionprops_table
 
 
@@ -275,10 +271,7 @@ class BinaryThreshold(Transform):
             image.ndim == 2
         ), f"input image has shape {image.shape}. Must convert to 1-channel image (H, W)."
         _, out = cv2.threshold(
-            src=image,
-            thresh=self.threshold,
-            maxval=self.max_value,
-            type=self.type,
+            src=image, thresh=self.threshold, maxval=self.max_value, type=self.type,
         )
         return out.astype(np.uint8)
 
@@ -1431,9 +1424,7 @@ class QuantifyMIF(Transform):
             ],
         )
         counts.obs = counts.obs.rename(columns={0: "x", 1: "y"})
-        counts.obs["coords"] = str(countsdataframe["coords"])
         counts.obs["filled_area"] = countsdataframe["filled_area"]
-        counts.obs["slice"] = str(countsdataframe["slice"])
         counts.obs["euler_number"] = countsdataframe["euler_number"]
         min_intensities = pd.DataFrame()
         for i in range(img.shape[-1]):
@@ -1446,8 +1437,7 @@ class QuantifyMIF(Transform):
         try:
             counts.obsm["spatial"] = np.array(counts.obs[["x", "y"]])
         except:
-            pass
-        counts.obs["tile"] = str(tile.coords)
+            print("warning: did not log coordinates in obsm")
         return counts
 
     def apply(self, tile):


### PR DESCRIPTION
This PR fixes a read/write bug when .h5path contains a counts matrix created by our QuantifyMIF transform #159. The problem was that certain types are not supported by AnnData. 

Meanwhile we now use proper scope 
```python3
with h5py.File() as f:
```
instead of 
```
f = h5py.File()
```
when adding counts.

Since read/write for .h5path breaks when reading a file edited by QuantifyMIF, I think we should add this change directly to master.