### PR TITLE
Fix env setup

### DIFF
--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -74,4 +74,5 @@ jobs:
       shell: bash -l {0}
       run: |
         cd docs
+        pip install -r readthedocs-requirements.txt
         make html

--- a/docs/readthedocs-requirements.txt
+++ b/docs/readthedocs-requirements.txt
@@ -1,7 +1,7 @@
-sphinx>=3.4.3
-nbsphinx>=0.8.1
-nbsphinx-link>=1.3.0
-sphinx-rtd-theme>=0.5.1
-sphinx-autoapi
-Ipython
-sphinx-copybutton
+sphinx==4.3.2
+nbsphinx==0.8.8
+nbsphinx-link==1.3.0
+sphinx-rtd-theme==1.0.0
+sphinx-autoapi==1.8.4
+ipython==7.30.1
+sphinx-copybutton==0.4.0

--- a/environment.yml
+++ b/environment.yml
@@ -8,30 +8,24 @@ dependencies:
     - pip==21.2.2
     - python==3.8
     - numpy==1.19.5
-    - scipy==1.7.1
+    - scipy==1.7.3
     - scikit-image==0.18.3
-    - matplotlib==3.1.3
+    - matplotlib==3.5.1
     - python-spams==2.6.1
     - openjdk==8.0.152
-    - pytorch==1.9.0
+    - pytorch==1.10.1
     - h5py==3.1.0
-    - dask==2021.7.1
-    - pydicom==2.1.2
+    - dask==2021.12.0
+    - pydicom==2.2.2
     - pytest==6.2.5
-    - pre-commit==2.13.0
+    - pre-commit==2.16.0
     - coverage==5.5
     - pip:
+        - python-bioformats==4.0.0
+        - python-javabridge==4.0.0
+        - deepcell==0.11.0
         - opencv-contrib-python==4.5.3.56
         - openslide-python==1.1.2
-        - javabridge==1.0.19
-        - python-bioformats==4.0.0
-        - scanpy==1.7.2
-        - anndata==0.7.6
-        - ipython==7.27.0
-        - sphinx==4.2.0
-        - nbsphinx==0.8.7
-        - nbsphinx-link==1.3.0
-        - sphinx-rtd-theme==1.0.0
-        - sphinx-autoapi==1.8.4
-        - sphinx-copybutton==0.4.0
-        - tqdm
+        - scanpy==1.8.2
+        - anndata==0.7.8
+        - tqdm==4.62.3

--- a/pathml/preprocessing/transforms.py
+++ b/pathml/preprocessing/transforms.py
@@ -12,7 +12,6 @@ import numpy as np
 import pandas as pd
 import pathml.core
 import pathml.core.slide_data
-import spams
 from pathml.utils import (
     RGB_to_GREY,
     RGB_to_HSI,
@@ -604,6 +603,10 @@ class StainNormalizationHE(Transform):
             Default can be used, or you can also fit to a reference slide of your choosing by calling
             :meth:`~pathml.preprocessing.transforms.StainNormalizationHE.fit_to_reference`.
 
+    Note:
+        If using ``stain_estimation_method = "Vahadane"``, `spams <http://thoth.inrialpes.fr/people/mairal/spams/>`_
+        must be installed, along with all of its dependencies (i.e. libblas & liblapack).
+
     References:
         Macenko, M., Niethammer, M., Marron, J.S., Borland, D., Woosley, J.T., Guan, X., Schmitt, C. and Thomas, N.E.,
         2009, June. A method for normalizing histology slides for quantitative analysis. In 2009 IEEE International
@@ -641,6 +644,14 @@ class StainNormalizationHE(Transform):
         assert (
             0 <= background_intensity <= 255
         ), f"Error: input background intensity {background_intensity} must be an integer between 0 and 255"
+
+        if stain_estimation_method.lower() == "vahadane":
+            try:
+                import spams
+            except (ImportError, ModuleNotFoundError):
+                raise Exception(
+                    "Vahadane method requires `spams` package to be installed"
+                )
 
         self.target = target.lower()
         self.stain_estimation_method = stain_estimation_method.lower()
@@ -730,6 +741,10 @@ class StainNormalizationHE(Transform):
         Args:
             image (np.ndarray): RGB image
         """
+        try:
+            import spams
+        except (ImportError, ModuleNotFoundError):
+            raise Exception("Vahadane method requires `spams` package to be installed")
         # convert to Optical Density (OD) space
         image_OD = RGB_to_OD(image)
         # reshape to (M*N)x3
@@ -830,6 +845,10 @@ class StainNormalizationHE(Transform):
             stain_matrix (np.ndarray): matrix of H and E stain vectors in optical density (OD) space.
                 Stain_matrix is (3, 2) and first column corresponds to hematoxylin by convention.
         """
+        try:
+            import spams
+        except (ImportError, ModuleNotFoundError):
+            raise Exception("Vahadane method requires `spams` package to be installed")
         image_OD = RGB_to_OD(image).reshape(-1, 3)
 
         # Get concentrations of each stain at each pixel

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setuptools.setup(
         "openslide-python",
         "pydicom",
         "h5py",
-        "spams",
         "scikit-learn",
         "dask[distributed]",
         "anndata>=0.7.6",


### PR DESCRIPTION
This PR should help with environment setup problems. 

- Removed `spams` as a dependency (#142). Instead, if a user wants to use Vahadane stain normalization, we check if spams can be imported and throw an error if not. Also added a note in the documentation pointing to the spams website for users to install. We have faced a lot of issues with spams installation, so this should make things smoother especially since many users have no need for the one functionality which requires spams
- Updated `environment.yml` with a working and reproducible environment that supports deepcell (#259)  