### PR TITLE
Bioformats dtype bug

### DIFF
--- a/pathml/core/slide_backends.py
+++ b/pathml/core/slide_backends.py
@@ -289,7 +289,7 @@ class BioFormatsBackend(SlideBackend):
 
         # map from ome pixel datatypes to numpy types. Based on:
         # https://github.com/CellProfiler/python-bioformats/blob/c03fb0988caf686251707adc4332d0aff9f02941/bioformats/omexml.py#L77-L87
-        # but specifying that float = float32 (np.float defaults to float62)
+        # but specifying that float = float32 (np.float defaults to float64)
         pixel_dtype_map = {
             bioformats.omexml.PT_INT8: np.dtype("int8"),
             bioformats.omexml.PT_INT16: np.dtype("int16"),


### PR DESCRIPTION
This is a fix for #271. Checks the pixel datatype from the OME metadata and uses that to scale the image appropriately before converting to uint8.

In my prototyping this seems to work but we need to add some tests for this