### PR TITLE
Bioformats xy ij

### DIFF
--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -40,6 +40,7 @@ jobs:
       # uses: conda-incubator/setup-miniconda@f4c00b0ec69bdc87b1ab4972613558dd9f4f36f3
       uses: conda-incubator/setup-miniconda@v2.0.0
       with:
+        add_pip_as_python_dependency: false
         environment-file: environment.yml
         activate-environment: pathml
         python-version: ${{ matrix.python-version }}

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -42,9 +42,10 @@ Coordinate system conventions
 
 With multiple tools for interacting with matrices/images, conflicting coordinate systems has been a common source of
 bugs. This is typically caused when mixing up (X, Y) coordinate systems and (i, j) coordinate systems. **To avoid these
-issues, we have adopted the (i, j) coordinate convention throughout PathML.** Developers should be careful
-about coordinate systems and make the necessary adjustments when using third-party tools so that users of PathML
-can rely on a consistent coordinate system when using our tools.
+issues, we have adopted the (i, j) coordinate convention throughout PathML.** This follows the convention used by
+NumPy and many others, where ``A[i, j]`` refers to the element of matrix A in the ith row, jth column.
+Developers should be careful about coordinate systems and make the necessary adjustments when using third-party tools
+so that users of PathML can rely on a consistent coordinate system when using our tools.
 
 Setting up a local development environment
 -------------------------------------------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -37,6 +37,15 @@ Request a new feature by filing an issue on GitHub. Make sure to include the fol
 For developers
 ==============
 
+Coordinate system conventions
+-----------------------------
+
+With multiple tools for interacting with matrices/images, conflicting coordinate systems has been a common source of
+bugs. This is typically caused when mixing up (X, Y) coordinate systems and (i, j) coordinate systems. **To avoid these
+issues, we have adopted the (i, j) coordinate convention throughout PathML.** Developers should be careful
+about coordinate systems and make the necessary adjustments when using third-party tools so that users of PathML
+can rely on a consistent coordinate system when using our tools.
+
 Setting up a local development environment
 -------------------------------------------
 
@@ -94,12 +103,15 @@ How to contribute code, documentation, etc.
 6. Push your changes and open a pull request on GitHub referencing the corresponding issue
 7. Respond to discussion/feedback about the pull request, make changes as necessary
 
-Versioning
-----------
+Versioning and Distributing
+---------------------------
 
 We use `semantic versioning`_. The version is tracked in ``pathml/_version.py`` and should be updated there as required.
-When new code is merged to the master branch on GitHub, the version should be incremented and the commit should
-be tagged in version format (e.g., "v1.0.0" for version 1.0.0).
+When new code is merged to the master branch on GitHub, the version should be incremented and a new release should be
+pushed. Releases can be created using the GitHub website interface, and should be tagged in version format
+(e.g., "v1.0.0" for version 1.0.0) and include release notes indicating what has changed.
+Once a new release is created, GitHub Actions workflows will automatically build and publish the updated package on
+PyPI and TestPyPI, as well as build and publish the Docker image to Docker Hub.
 
 Code Quality
 ------------

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
     - pytorch
 
 dependencies:
-    - pip==21.2.2
+    - pip==21.3.1
     - python==3.8
     - numpy==1.19.5
     - scipy==1.7.3

--- a/pathml/core/slide_backends.py
+++ b/pathml/core/slide_backends.py
@@ -450,12 +450,6 @@ class BioFormatsBackend(SlideBackend):
                             XYWH=(location[1], location[0], size[1], size[0]),
                         )
                         slicearray = np.asarray(slicearray)
-                        # some file formats read x, y out of order, transpose
-                        if slicearray.shape[:2] != array.shape[:2]:
-                            slicearray = np.transpose(slicearray)
-                            # in 2d undoes transpose
-                            if len(sample.shape) == 3:
-                                slicearray = np.moveaxis(slicearray, 0, -1)
                         if len(sample.shape) == 3:
                             array[:, :, z, :, t] = slicearray
                         else:

--- a/pathml/core/slide_backends.py
+++ b/pathml/core/slide_backends.py
@@ -435,7 +435,6 @@ class BioFormatsBackend(SlideBackend):
                             )
                             slicearray = np.asarray(slicearray)
                             # some file formats read x, y out of order, transpose
-                            slicearray = np.transpose(slicearray)
                             array[:, :, z, c, t] = slicearray
 
             # in this case, channels are correctly stored as channels, and we can support multi-level images as series

--- a/pathml/core/slide_data.py
+++ b/pathml/core/slide_data.py
@@ -91,6 +91,7 @@ class SlideData:
         volumetric=None,
         time_series=None,
         counts=None,
+        dtype=None,
     ):
         # check inputs
         assert masks is None or isinstance(
@@ -173,7 +174,7 @@ class SlideData:
         if backend.lower() == "openslide":
             backend_obj = pathml.core.OpenSlideBackend(filepath)
         elif backend.lower() == "bioformats":
-            backend_obj = pathml.core.BioFormatsBackend(filepath)
+            backend_obj = pathml.core.BioFormatsBackend(filepath, dtype)
         elif backend.lower() == "dicom":
             backend_obj = pathml.core.DICOMBackend(filepath)
         elif backend.lower() == "h5path":

--- a/pathml/core/tile.py
+++ b/pathml/core/tile.py
@@ -108,7 +108,7 @@ class Tile:
             # remove any Nones
             stain_type_dict = {key: val for key, val in stain_type_dict.items() if val}
             if stain_type_dict:
-                slide_type = pathml.core.types.SlideType(**stain_type_dict)
+                slide_type = pathml.core.slide_types.SlideType(**stain_type_dict)
 
         assert counts is None or isinstance(
             counts, anndata.AnnData

--- a/pathml/preprocessing/transforms.py
+++ b/pathml/preprocessing/transforms.py
@@ -12,15 +12,11 @@ import numpy as np
 import pandas as pd
 import pathml.core
 import pathml.core.slide_data
-from pathml.utils import (
-    RGB_to_GREY,
-    RGB_to_HSI,
-    RGB_to_HSV,
-    RGB_to_OD,
-    normalize_matrix_cols,
-)
+from pathml.utils import (RGB_to_GREY, RGB_to_HSI, RGB_to_HSV, RGB_to_OD,
+                          normalize_matrix_cols)
 from skimage import restoration
-from skimage.exposure import equalize_adapthist, equalize_hist, rescale_intensity
+from skimage.exposure import (equalize_adapthist, equalize_hist,
+                              rescale_intensity)
 from skimage.measure import regionprops_table
 
 
@@ -1405,7 +1401,9 @@ class SegmentMIF(Transform):
 
 class QuantifyMIF(Transform):
     """
-    Convert segmented image into anndata.AnnData counts object.
+    Convert segmented image into anndata.AnnData counts object `AnnData <https://anndata.readthedocs.io/en/latest/>`_.
+    Counts objects are used to interface with the Python single cell analysis ecosystem `Scanpy <https://scanpy.readthedocs.io/en/stable/>`_.
+    The counts object contains a summary of protein expression statistics in each cell along with its coordinate.
 
     Args:
         segmentation_mask (str): key indicating which mask to use as label image
@@ -1443,13 +1441,13 @@ class QuantifyMIF(Transform):
         counts = anndata.AnnData(
             X=X,
             obs=[
-                tuple([x + tile.coords[0], y + tile.coords[1]])
-                for x, y in zip(
+                tuple([i + tile.coords[0], j + tile.coords[1]])
+                for i, j in zip(
                     countsdataframe["centroid-0"], countsdataframe["centroid-1"]
                 )
             ],
         )
-        counts.obs = counts.obs.rename(columns={0: "x", 1: "y"})
+        counts.obs = counts.obs.rename(columns={0: "y", 1: "x"})
         counts.obs["filled_area"] = countsdataframe["filled_area"]
         counts.obs["euler_number"] = countsdataframe["euler_number"]
         min_intensities = pd.DataFrame()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,8 @@ requires = [
     "wheel"
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]

--- a/tests/core_tests/test_slide_backends.py
+++ b/tests/core_tests/test_slide_backends.py
@@ -108,9 +108,9 @@ def test_extract_region_dicom(backend, location, size, level):
 @pytest.mark.parametrize(
     "backend,shape",
     [
-        (bioformats_backend(), (640, 480)),
+        (bioformats_backend(), (480, 640)),
         (dicom_backend(), (2638, 3236)),
-        (bioformats_backend_qptiff(), (1920, 1440)),
+        (bioformats_backend_qptiff(), (1440, 1920)),
     ],
 )
 @pytest.mark.parametrize("pad", [True, False])
@@ -153,8 +153,8 @@ def test_tile_generator_with_level(backend, shape, tile_shape, pad, level):
     "backend,shape",
     [
         (openslide_backend(), (2967, 2220)),
-        (bioformats_backend(), (640, 480)),
-        (bioformats_backend_qptiff(), (1920, 1440)),
+        (bioformats_backend(), (480, 640)),
+        (bioformats_backend_qptiff(), (1440, 1920)),
         (dicom_backend(), (2638, 3236)),
     ],
 )

--- a/tests/preprocessing_tests/test_transforms.py
+++ b/tests/preprocessing_tests/test_transforms.py
@@ -27,6 +27,7 @@ from pathml.preprocessing import (
     RescaleIntensity,
 )
 from pathml.utils import RGB_to_GREY
+from pathml.core import Tile
 
 
 @pytest.mark.parametrize("ksize", [3, 7, 21])
@@ -185,6 +186,20 @@ def test_quantify_mif(tileVectra):
     t2.apply(tileVectra)
     t.apply(tileVectra)
     assert tileVectra.counts
+
+
+def test_quantify_mif_coords():
+    # make sure that QuantifyMIF uses i,j coordinates
+    # make fake im with a single region
+    im = np.zeros(shape=(50, 50, 3))
+    seg = np.zeros(shape=(50, 50, 1), dtype=np.uint8)
+    # add a region with known centroid at (i=27, j=7) == (x=7, y=27)
+    seg[25:30, 5:10] = 1
+    tile = Tile(image=im, coords=(0, 0), masks={"seg": seg}, stain="Fluor")
+    quantifymif = QuantifyMIF(segmentation_mask="seg")
+    quantifymif.apply(tile)
+    assert tile.counts.obs.x[0] == 7
+    assert tile.counts.obs.y[0] == 27
 
 
 def test_collapse_runs_vectra(tileVectra):


### PR DESCRIPTION
Update BioFormatsBackend to use i,j coordinates (#276). Also adds a section in the docs for developers to clarify. Also registers the pytest mark to silence warning when running tests.