### PR TITLE
No normalize

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -42,9 +42,10 @@ Coordinate system conventions
 
 With multiple tools for interacting with matrices/images, conflicting coordinate systems has been a common source of
 bugs. This is typically caused when mixing up (X, Y) coordinate systems and (i, j) coordinate systems. **To avoid these
-issues, we have adopted the (i, j) coordinate convention throughout PathML.** Developers should be careful
-about coordinate systems and make the necessary adjustments when using third-party tools so that users of PathML
-can rely on a consistent coordinate system when using our tools.
+issues, we have adopted the (i, j) coordinate convention throughout PathML.** This follows the convention used by
+NumPy and many others, where ``A[i, j]`` refers to the element of matrix A in the ith row, jth column.
+Developers should be careful about coordinate systems and make the necessary adjustments when using third-party tools
+so that users of PathML can rely on a consistent coordinate system when using our tools.
 
 Setting up a local development environment
 -------------------------------------------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -37,6 +37,15 @@ Request a new feature by filing an issue on GitHub. Make sure to include the fol
 For developers
 ==============
 
+Coordinate system conventions
+-----------------------------
+
+With multiple tools for interacting with matrices/images, conflicting coordinate systems has been a common source of
+bugs. This is typically caused when mixing up (X, Y) coordinate systems and (i, j) coordinate systems. **To avoid these
+issues, we have adopted the (i, j) coordinate convention throughout PathML.** Developers should be careful
+about coordinate systems and make the necessary adjustments when using third-party tools so that users of PathML
+can rely on a consistent coordinate system when using our tools.
+
 Setting up a local development environment
 -------------------------------------------
 
@@ -94,12 +103,15 @@ How to contribute code, documentation, etc.
 6. Push your changes and open a pull request on GitHub referencing the corresponding issue
 7. Respond to discussion/feedback about the pull request, make changes as necessary
 
-Versioning
-----------
+Versioning and Distributing
+---------------------------
 
 We use `semantic versioning`_. The version is tracked in ``pathml/_version.py`` and should be updated there as required.
-When new code is merged to the master branch on GitHub, the version should be incremented and the commit should
-be tagged in version format (e.g., "v1.0.0" for version 1.0.0).
+When new code is merged to the master branch on GitHub, the version should be incremented and a new release should be
+pushed. Releases can be created using the GitHub website interface, and should be tagged in version format
+(e.g., "v1.0.0" for version 1.0.0) and include release notes indicating what has changed.
+Once a new release is created, GitHub Actions workflows will automatically build and publish the updated package on
+PyPI and TestPyPI, as well as build and publish the Docker image to Docker Hub.
 
 Code Quality
 ------------

--- a/pathml/core/slide_backends.py
+++ b/pathml/core/slide_backends.py
@@ -367,6 +367,7 @@ class BioFormatsBackend(SlideBackend):
             series_as_channels (bool): Whether to treat image series as channels. If ``True``, multi-level images
                 are not supported. Defaults to ``False``.
             normalize (bool, optional): Whether to normalize the image to int8 before returning. Defaults to True.
+                If False, image will be returned as-is immediately after reading, typically in float64.
 
         Returns:
             np.ndarray: image at the specified region. 5-D array of (i, j, z, c, t)

--- a/pathml/core/slide_data.py
+++ b/pathml/core/slide_data.py
@@ -279,6 +279,7 @@ class SlideData:
             write_dir (str): Path to directory to write the processed slide to. The processed SlideData object
                 will be written to the directory immediately after the pipeline has completed running.
                 The filepath will default to "<write_dir>/<slide.name>.h5path. Defaults to ``None``.
+            **kwargs: Other arguments passed through to ``generate_tiles()`` method of the backend.
         """
         assert isinstance(
             pipeline, pathml.preprocessing.pipeline.Pipeline
@@ -381,8 +382,8 @@ class SlideData:
             location (Tuple[int, int]): Location of top-left corner of tile (i, j)
             size (Union[int, Tuple[int, int]]): Size of each tile. May be a tuple of (height, width) or a
                 single integer, in which case square tiles of that size are generated.
-            *args: positional arguments passed through
-            **kwargs: keyword arguments passed through
+            *args: positional arguments passed through to ``extract_region()`` method of the backend.
+            **kwargs: keyword arguments passed through to ``extract_region()`` method of the backend.
 
         Returns:
             np.ndarray: image at the specified region

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,8 @@ requires = [
     "wheel"
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]

--- a/tests/core_tests/test_slide_backends.py
+++ b/tests/core_tests/test_slide_backends.py
@@ -46,6 +46,16 @@ def test_extract_region(backend, location, size, level):
     assert region.dtype == np.uint8
 
 
+@pytest.mark.parametrize("backend", [bioformats_backend(), bioformats_backend_qptiff()])
+@pytest.mark.parametrize("normalize", [True, False])
+def test_extract_region_bioformats_no_normalize(backend, normalize):
+    reg = backend.extract_region(location=(0, 0), size=10, normalize=normalize)
+    if normalize:
+        assert reg.dtype == np.dtype("uint8")
+    else:
+        assert reg.dtype == np.dtype("float64")
+
+
 @pytest.mark.parametrize("shape", [500, (500, 250)])
 def test_extract_region_openslide(example_slide_data, shape):
     """
@@ -147,6 +157,17 @@ def test_tile_generator_with_level(backend, shape, tile_shape, pad, level):
             [1 + (shape[i] // tile_shape[i]) for i in range(len(shape))]
         )
     assert all([isinstance(tile, Tile) for tile in tiles])
+
+
+@pytest.mark.parametrize("backend", [bioformats_backend(), bioformats_backend_qptiff()])
+@pytest.mark.parametrize("normalize", [True, False])
+def test_generate_tiles_bioformats_no_normalize(backend, normalize):
+    gen = backend.generate_tiles(shape=10, normalize=normalize)
+    tile1 = next(gen)
+    if normalize:
+        assert tile1.image.dtype == np.dtype("uint8")
+    else:
+        assert tile1.image.dtype == np.dtype("float64")
 
 
 @pytest.mark.parametrize(

--- a/tests/core_tests/test_slide_backends.py
+++ b/tests/core_tests/test_slide_backends.py
@@ -108,9 +108,9 @@ def test_extract_region_dicom(backend, location, size, level):
 @pytest.mark.parametrize(
     "backend,shape",
     [
-        (bioformats_backend(), (640, 480)),
+        (bioformats_backend(), (480, 640)),
         (dicom_backend(), (2638, 3236)),
-        (bioformats_backend_qptiff(), (1920, 1440)),
+        (bioformats_backend_qptiff(), (1440, 1920)),
     ],
 )
 @pytest.mark.parametrize("pad", [True, False])
@@ -153,8 +153,8 @@ def test_tile_generator_with_level(backend, shape, tile_shape, pad, level):
     "backend,shape",
     [
         (openslide_backend(), (2967, 2220)),
-        (bioformats_backend(), (640, 480)),
-        (bioformats_backend_qptiff(), (1920, 1440)),
+        (bioformats_backend(), (480, 640)),
+        (bioformats_backend_qptiff(), (1440, 1920)),
         (dicom_backend(), (2638, 3236)),
     ],
 )


### PR DESCRIPTION
Adds option to skip normalization altogether for `BioFormatsBackend.extract_region()`. Related to #271 #272 #274