### PR TITLE
dont use default pip version

### DIFF
--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -40,6 +40,7 @@ jobs:
       # uses: conda-incubator/setup-miniconda@f4c00b0ec69bdc87b1ab4972613558dd9f4f36f3
       uses: conda-incubator/setup-miniconda@v2.0.0
       with:
+        add_pip_as_python_dependency: false
         environment-file: environment.yml
         activate-environment: pathml
         python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
Similar to #288 but testing if the change to the conda setup config alone will resolve the problem. If so, I think this would be more maintainable, since it doesn't actually make any changes to the requirements themselves

adds `add_pip_as_python_dependency: false` to config, so that pip is installed from the environment file instead of by default (this should mean that it will respect the pinned pip version, which I don't think it's doing now)