### PR TITLE
Fix tiling bug

### DIFF
--- a/pathml/core/slide_backends.py
+++ b/pathml/core/slide_backends.py
@@ -198,16 +198,19 @@ class OpenSlideBackend(SlideBackend):
 
         stride_i, stride_j = stride
 
-        if pad:
-            n_chunk_i = i // stride_i + 1
-            n_chunk_j = j // stride_j + 1
-
+        # calculate number of expected tiles
+        # check for tile shape evenly dividing slide shape to fix https://github.com/Dana-Farber-AIOS/pathml/issues/305
+        if pad and i % stride_i != 0:
+            n_tiles_i = i // stride_i + 1
         else:
-            n_chunk_i = (i - shape[0]) // stride_i + 1
-            n_chunk_j = (j - shape[1]) // stride_j + 1
+            n_tiles_i = (i - shape[0]) // stride_i + 1
+        if pad and j % stride_j != 0:
+            n_tiles_j = j // stride_j + 1
+        else:
+            n_tiles_j = (j - shape[1]) // stride_j + 1
 
-        for ix_i in range(n_chunk_i):
-            for ix_j in range(n_chunk_j):
+        for ix_i in range(n_tiles_i):
+            for ix_j in range(n_tiles_j):
                 coords = (int(ix_i * stride_i), int(ix_j * stride_j))
                 # get image for tile
                 tile_im = self.extract_region(location=coords, size=shape, level=level)
@@ -549,16 +552,19 @@ class BioFormatsBackend(SlideBackend):
 
         stride_i, stride_j = stride
 
-        if pad:
-            n_chunk_i = i // stride_i + 1
-            n_chunk_j = j // stride_j + 1
-
+        # calculate number of expected tiles
+        # check for tile shape evenly dividing slide shape to fix https://github.com/Dana-Farber-AIOS/pathml/issues/305
+        if pad and i % stride_i != 0:
+            n_tiles_i = i // stride_i + 1
         else:
-            n_chunk_i = (i - shape[0]) // stride_i + 1
-            n_chunk_j = (j - shape[1]) // stride_j + 1
+            n_tiles_i = (i - shape[0]) // stride_i + 1
+        if pad and j % stride_j != 0:
+            n_tiles_j = j // stride_j + 1
+        else:
+            n_tiles_j = (j - shape[1]) // stride_j + 1
 
-        for ix_i in range(n_chunk_i):
-            for ix_j in range(n_chunk_j):
+        for ix_i in range(n_tiles_i):
+            for ix_j in range(n_tiles_j):
                 coords = (int(ix_i * stride_i), int(ix_j * stride_j))
                 if coords[0] + shape[0] < i and coords[1] + shape[1] < j:
                     # get image for tile

--- a/tests/core_tests/test_slide_backends.py
+++ b/tests/core_tests/test_slide_backends.py
@@ -139,6 +139,17 @@ def test_tile_generator(backend, shape, tile_shape, pad):
     assert all([isinstance(tile, Tile) for tile in tiles])
 
 
+@pytest.mark.parametrize("backend", [BioFormatsBackend, OpenSlideBackend])
+@pytest.mark.parametrize("pad", [True, False])
+def test_tile_generator_with_pad_evenly_divide(backend, pad):
+    """When tile shape evenly divides slide shape, padding should make no difference"""
+    slide = backend("tests/testdata/smalltif.tif")
+    tile_shape = 160
+    shape = (480, 640)
+    tiles = list(slide.generate_tiles(shape=tile_shape, pad=pad))
+    assert len(tiles) == np.prod([shape_i / tile_shape for shape_i in shape])
+
+
 @pytest.mark.parametrize("backend,shape", [(openslide_backend(), (2967, 2220))])
 @pytest.mark.parametrize("pad", [True, False])
 @pytest.mark.parametrize("tile_shape", [500, (500, 500)])


### PR DESCRIPTION
Fix logic in `generate_tiles()` for OpenSlideBackend and BioFormatsBackend so that when tile shape evenly divides into slide shape, padding argument is ignored as expected and no errors are raised
This fixes #305