### PR TITLE
pin protobuf to 3.20.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ COPY tests/ /opt/pathml/tests
 
 # install pathml and deepcell
 RUN pip3 install pip==21.3.1 \
-    && pip3 install numpy==1.19.5 spams==2.6.2.5 \
+    && pip3 install numpy==1.19.5 spams==2.6.2.5 protobuf==3.20.1\
     && pip3 install python-bioformats==4.0.0 deepcell /opt/pathml/ pytest
 
 # run tests to verify container

--- a/environment.yml
+++ b/environment.yml
@@ -23,6 +23,7 @@ dependencies:
     - pip:
         - python-bioformats==4.0.0
         - python-javabridge==4.0.0
+        - protobuf==3.20.1
         - deepcell==0.11.0
         - opencv-contrib-python==4.5.3.56
         - openslide-python==1.1.2


### PR DESCRIPTION
Tests started failing unexpectedly: https://github.com/Dana-Farber-AIOS/pathml/runs/6749244149?check_suite_focus=true

The problem seems to be an error raised by the protobuf package. Checking the logs shows that the version of protobuf in the failing test ([4.21.1](https://github.com/Dana-Farber-AIOS/pathml/runs/6749244149?check_suite_focus=true#step:7:247)) is different from the one in the last passing test ([3.20.1](https://github.com/Dana-Farber-AIOS/pathml/runs/6482168049?check_suite_focus=true#step:7:248)). Other people have reported similar issue (https://github.com/protocolbuffers/protobuf/issues/10051). This PR pins protobuf version to 3.20.1 to try to fix the test suite