### PR TITLE
allow manual workflow triggering

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,6 +1,7 @@
 name: Publish PathML distribution to PyPI and TestPyPI
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
 

--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -1,6 +1,7 @@
 name: Tests
 
-on: 
+on:
+  workflow_dispatch:
   pull_request:
     branches:
       - dev


### PR DESCRIPTION
This updates github Actions workflow files to enable manual triggering of workflows, so we can re-run them as needed. 
We already had this in place for the docker workflow, but now we will have it for the others as well