### PR TITLE
Update environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,7 @@ dependencies:
         - protobuf==3.20.1
         - deepcell==0.11.0
         - opencv-contrib-python==4.5.3.56
-        - openslide-python==1.1.2
+        - openslide-python==1.2.0
         - scanpy==1.8.2
         - anndata==0.7.8
         - tqdm==4.62.3


### PR DESCRIPTION
Update openslide-python to v1.2.0 to resolve 'ANTIALIAS' AttributeError

This commit upgrades openslide-python to version 1.2.0 to address an AttributeError related to the 'ANTIALIAS' attribute in the PIL.Image module. The issue was triggered due to the deprecation of 'ANTIALIAS' in Pillow v10.0.0.

https://stackoverflow.com/questions/76616042/attributeerror-module-pil-image-has-no-attribute-antialias

https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#constants
