### PR TITLE
Inference

### DIFF
--- a/.github/workflows/publish-to-docker-hub.yml
+++ b/.github/workflows/publish-to-docker-hub.yml
@@ -27,9 +27,10 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2.7.0
+        uses: docker/build-push-action@v4 # prev 2.7.0
         with:
           context: .
+          platforms: linux/amd64,linux/arm64 # new line for m1/m2 macs 
           push: true
           tags: |
             pathml/pathml:latest

--- a/.github/workflows/publish-to-docker-hub.yml
+++ b/.github/workflows/publish-to-docker-hub.yml
@@ -27,10 +27,10 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v4 # prev 2.7.0
+        uses: docker/build-push-action@v4 
         with:
           context: .
-          platforms: linux/amd64,linux/arm64 # new line for m1/m2 macs 
+          platforms: linux/amd64,linux/arm64  
           push: true
           tags: |
             pathml/pathml:latest

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
 
 dependencies:
     - pip==21.3.1
-    - numpy==1.21.6
+    - numpy==1.25.2 # orig = 1.19.5
     - scipy==1.7.3
     - scikit-image==0.18.3
     - matplotlib==3.5.1
@@ -15,20 +15,19 @@ dependencies:
     - h5py==3.1.0
     - dask==2021.12.0
     - pydicom==2.2.2
-    # - pytest==6.2.5
-    - pytest==7.4.0
+    - pytest==7.4.0 # orig = 6.2.5
     - pre-commit==2.16.0
     - coverage==5.5
     - pip:
         - python-bioformats==4.0.0
         - python-javabridge==4.0.0
         - protobuf==3.20.2
-        - deepcell==0.12.7
+        - deepcell==0.12.7 # orig = 0.11.0
         - onnx==1.14.0
         - onnxruntime==1.15.1
         - opencv-contrib-python==4.5.3.56
         - openslide-python==1.2.0
-        - pandas==1.5.2 
+        - pandas==1.5.2 # orig no req
         - scanpy==1.8.2
         - anndata==0.7.8
         - tqdm==4.62.3

--- a/environment.yml
+++ b/environment.yml
@@ -23,6 +23,8 @@ dependencies:
         - python-javabridge==4.0.0
         - protobuf==3.20.1
         - deepcell==0.11.0
+        - onnx==1.14.0
+        - onnxruntime==1.15.1
         - opencv-contrib-python==4.5.3.56
         - openslide-python==1.2.0 
         - scanpy==1.8.2

--- a/environment.yml
+++ b/environment.yml
@@ -27,7 +27,8 @@ dependencies:
         - onnx==1.14.0
         - onnxruntime==1.15.1
         - opencv-contrib-python==4.5.3.56
-        - openslide-python==1.2.0 
+        - openslide-python==1.2.0
+        - pandas==1.5.2 
         - scanpy==1.8.2
         - anndata==0.7.8
         - tqdm==4.62.3

--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,7 @@ dependencies:
         - protobuf==3.20.1
         - deepcell==0.11.0
         - opencv-contrib-python==4.5.3.56
-        - openslide-python==1.1.2
+        - openslide-python==1.2.0
         - scanpy==1.8.2
         - anndata==0.7.8
         - tqdm==4.62.3

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
 
 dependencies:
     - pip==21.3.1
-    - numpy==1.19.5
+    - numpy==1.21.6
     - scipy==1.7.3
     - scikit-image==0.18.3
     - matplotlib==3.5.1

--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,7 @@ dependencies:
     - pip:
         - python-bioformats==4.0.0
         - python-javabridge==4.0.0
-        - protobuf==3.20.1
+        - protobuf==3.20.2
         - deepcell==0.11.0
         - onnx==1.14.0
         - onnxruntime==1.15.1

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
 
 dependencies:
     - pip==21.3.1
-    - numpy==1.25.2 # orig = 1.19.5
+    - numpy==1.24.0 # orig = 1.19.5
     - scipy==1.7.3
     - scikit-image==0.18.3
     - matplotlib==3.5.1

--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,8 @@ dependencies:
         - python-bioformats==4.0.0
         - python-javabridge==4.0.0
         - protobuf==3.20.2
-        - deepcell==0.11.0
+        # - deepcell==0.11.0
+        - deepcell==0.12.7
         - onnx==1.14.0
         - onnxruntime==1.15.1
         - opencv-contrib-python==4.5.3.56

--- a/environment.yml
+++ b/environment.yml
@@ -27,8 +27,8 @@ dependencies:
         - onnxruntime==1.15.1
         - opencv-contrib-python==4.5.3.56
         - openslide-python==1.2.0
-        - pandas==1.5.2 # orig no req
         - scanpy==1.8.2
         - anndata==0.7.8
         - tqdm==4.62.3
         - loguru==0.5.3
+        - pandas==1.5.2 # orig no req

--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,6 @@ dependencies:
         - python-bioformats==4.0.0
         - python-javabridge==4.0.0
         - protobuf==3.20.2
-        # - deepcell==0.11.0
         - deepcell==0.12.7
         - onnx==1.14.0
         - onnxruntime==1.15.1

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
 
 dependencies:
     - pip==21.3.1
-    - numpy==1.24.0 # orig = 1.19.5
+    - numpy==1.22.4 # orig = 1.19.5
     - scipy==1.7.3
     - scikit-image==0.18.3
     - matplotlib==3.5.1

--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,7 @@ dependencies:
         - protobuf==3.20.1
         - deepcell==0.11.0
         - opencv-contrib-python==4.5.3.56
-        - openslide-python==1.2.0
+        - openslide-python==1.2.0 
         - scanpy==1.8.2
         - anndata==0.7.8
         - tqdm==4.62.3

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,8 @@ dependencies:
     - h5py==3.1.0
     - dask==2021.12.0
     - pydicom==2.2.2
-    - pytest==6.2.5
+    # - pytest==6.2.5
+    - pytest==7.4.0
     - pre-commit==2.16.0
     - coverage==5.5
     - pip:

--- a/pathml/__init__.py
+++ b/pathml/__init__.py
@@ -6,7 +6,7 @@ License: GNU GPL 2.0
 from . import datasets as ds
 from . import ml
 from . import preprocessing as pp
-import .inference 
+from . import inference
 from ._logging import PathMLLogger
 from ._version import __version__
 from .core import *  # noqa: F403

--- a/pathml/__init__.py
+++ b/pathml/__init__.py
@@ -6,6 +6,7 @@ License: GNU GPL 2.0
 from . import datasets as ds
 from . import ml
 from . import preprocessing as pp
+from .inference import * 
 from ._logging import PathMLLogger
 from ._version import __version__
 from .core import *  # noqa: F403

--- a/pathml/__init__.py
+++ b/pathml/__init__.py
@@ -6,7 +6,7 @@ License: GNU GPL 2.0
 from . import datasets as ds
 from . import ml
 from . import preprocessing as pp
-from .inference import * 
+import .inference 
 from ._logging import PathMLLogger
 from ._version import __version__
 from .core import *  # noqa: F403

--- a/pathml/__init__.py
+++ b/pathml/__init__.py
@@ -1,12 +1,11 @@
 """
-Copyright 2021, Dana-Farber Cancer Institute and Weill Cornell Medicine
+Copyright 2023, Dana-Farber Cancer Institute and Weill Cornell Medicine
 License: GNU GPL 2.0
 """
 
 from . import datasets as ds
-from . import ml
+from . import inference, ml
 from . import preprocessing as pp
-from . import inference
 from ._logging import PathMLLogger
 from ._version import __version__
 from .core import *  # noqa: F403

--- a/pathml/inference/__init__.py
+++ b/pathml/inference/__init__.py
@@ -9,5 +9,5 @@ from .inference import (
     InferenceBase,
     Inference,
     HaloAIInference,
-    RemoteTestHoverNet
+    RemoteTestHoverNet,
 )

--- a/pathml/inference/__init__.py
+++ b/pathml/inference/__init__.py
@@ -5,9 +5,9 @@ License: GNU GPL 2.0
 
 from .inference import (
     remove_initializer_from_input,
-    check_onnx_clean, 
-    InferenceBase, 
-    Inference, 
-    HaloAIInference, 
+    check_onnx_clean,
+    InferenceBase
+    Inference,
+    HaloAIInference,
     RemoteTestHoverNet
 )

--- a/pathml/inference/__init__.py
+++ b/pathml/inference/__init__.py
@@ -1,0 +1,6 @@
+"""
+Copyright 2023, Dana-Farber Cancer Institute and Weill Cornell Medicine
+License: GNU GPL 2.0
+"""
+
+from .inference import * 

--- a/pathml/inference/__init__.py
+++ b/pathml/inference/__init__.py
@@ -6,7 +6,7 @@ License: GNU GPL 2.0
 from .inference import (
     remove_initializer_from_input,
     check_onnx_clean,
-    InferenceBase
+    InferenceBase,
     Inference,
     HaloAIInference,
     RemoteTestHoverNet

--- a/pathml/inference/__init__.py
+++ b/pathml/inference/__init__.py
@@ -3,4 +3,11 @@ Copyright 2023, Dana-Farber Cancer Institute and Weill Cornell Medicine
 License: GNU GPL 2.0
 """
 
-from .inference import * 
+from .inference import (
+    remove_initializer_from_input,
+    check_onnx_clean, 
+    InferenceBase, 
+    Inference, 
+    HaloAIInference, 
+    RemoteTestHoverNet
+)

--- a/pathml/inference/__init__.py
+++ b/pathml/inference/__init__.py
@@ -4,10 +4,10 @@ License: GNU GPL 2.0
 """
 
 from .inference import (
-    remove_initializer_from_input,
-    check_onnx_clean,
-    InferenceBase,
-    Inference,
     HaloAIInference,
+    Inference,
+    InferenceBase,
     RemoteTestHoverNet,
+    check_onnx_clean,
+    remove_initializer_from_input,
 )

--- a/pathml/inference/inference.py
+++ b/pathml/inference/inference.py
@@ -1,0 +1,314 @@
+"""
+Copyright 2023, Dana-Farber Cancer Institute and Weill Cornell Medicine
+License: GNU GPL 2.0
+"""
+
+import os
+import numpy as np 
+from pathml.core import SlideData, Tile
+from pathml.preprocessing import Pipeline
+import pathml.preprocessing.transforms as Transforms
+import onnx
+import onnxruntime as ort 
+import pathml 
+
+
+def remove_initializer_from_input(model_path, new_path):
+    """Removes initializers from HaloAI ONNX models
+    Taken from https://github.com/microsoft/onnxruntime/blob/main/tools/python/remove_initializer_from_input.py
+    
+    Args:
+        model_path (str): path to ONNX model,
+        new_path (str): path to save adjusted model w/o initializers,
+
+    Returns:
+        ONNX model w/o initializers to run inference using PathML
+    """ 
+    
+    model = onnx.load(model_path)
+
+    inputs = model.graph.input
+    name_to_input = {}
+    for onnx_input in inputs:
+        name_to_input[onnx_input.name] = onnx_input
+
+    for initializer in model.graph.initializer:
+        if initializer.name in name_to_input:
+            inputs.remove(name_to_input[initializer.name])
+
+    onnx.save(model, new_path)
+
+    
+def check_onnx_clean(model_path):
+    """Checks if the model has had it's initalizers removed from input graph. 
+    Adapted from from https://github.com/microsoft/onnxruntime/blob/main/tools/python/remove_initializer_from_input.py
+    
+    Args:
+        model_path (str): path to ONNX model,
+
+    Returns:
+        Boolean if there are initializers in input graph. 
+    """ 
+    
+    model = onnx.load(model_path)
+
+    inputs = model.graph.input
+    name_to_input = {}
+    for onnx_input in inputs:
+        name_to_input[onnx_input.name] = onnx_input
+
+    for initializer in model.graph.initializer:
+        if initializer.name in name_to_input:
+            return True 
+
+# Base class
+# I think this should still inherit from Transforms to make the tiling easier/so we don't have to rewrite so much existing code 
+class InferenceBase(Transforms.Transform):
+    """
+    Base class for all ONNX Models.
+    Each transform must operate on a Tile.
+    """
+    
+    def __init__(self): 
+        self.model_card = {
+            'name' : None, 
+            'num_classes' : None,
+            'model_type' : None, 
+            'notes' : None,  
+            'model_input_notes': None, 
+            'model_output_notes' : None,
+            'citation': None 
+        } 
+
+    def __repr__(self):
+        return "Base class for all ONNX models"
+    
+    
+    def get_model_card(self):
+        return self.model_card
+    
+    def set_name(self, name):
+        self.model_card['name'] = name  
+        
+    def set_num_classes(self, num):
+        self.model_card['num_classes'] = num
+    
+    def set_model_type(self, model_type):
+        self.model_card['model_type'] = model_type
+        
+    def set_notes(self, note):
+        self.model_card['notes'] = note 
+    
+    def set_model_input_notes(self, note):
+        self.model_card['model_input_notes'] = note
+    
+    def set_model_output_notes(self, note):
+        self.model_card['model_output_notes'] = note
+    
+    def set_citation(self, citation):
+        self.model_card['citation'] = citation  
+        
+    
+    def reshape(self, image):
+        """standard reshaping of tile image"""
+        # flip dimensions 
+        # follows convention used here https://github.com/Dana-Farber-AIOS/pathml/blob/master/pathml/ml/dataset.py
+        
+        if image.ndim == 3:
+            # swap axes from HWC to CHW 
+            image = image.transpose(2, 0, 1)
+            # add a dimesion bc onnx models usually have batch size as first dim: e.g. (1, channel, height, width) 
+            image = np.expand_dims(image, axis = 0)
+            
+            return image 
+        else:
+            # in this case, we assume that we have XYZCT channel order
+            # so we swap axes to TCZYX for batching
+            # note we are not adding a dim here for batch bc we assume that subsetting will create a batch "placeholder" dim
+            image = image.T
+            
+            return image 
+
+    def F(self, target):
+        """functional implementation"""
+        raise NotImplementedError
+
+    def apply(self, tile):
+        """modify Tile object in-place"""
+        raise NotImplementedError
+        
+# class to handle local onnx models 
+class Inference(InferenceBase):
+    """Transformation to run inferrence on ONNX model.
+    
+    Assumptions:
+        - The ONNX model has been cleaned by `remove_initializer_from_input` first 
+    
+    Args:
+        model_path (str): path to ONNX model w/o initializers,
+        input_name (str): name of the input the ONNX model accepts
+    """ 
+    def __init__(self, model_path = None, input_name = 'data', num_classes = None, model_type = None, local = True):
+        super().__init__() 
+        
+        
+        self.input_name = input_name 
+        self.num_classes = num_classes
+        self.model_type = model_type
+        self.local = local
+        
+        if self.local:
+            # using a local onnx model
+            self.model_path = model_path
+        else: 
+            # if using a model from the model zoo, set the local path to a temp file
+            self.model_path = 'temp.onnx' 
+           
+        # fill in parts of the model_card with the following info
+        self.model_card['num_classes'] = self.num_classes
+        self.model_card['model_type'] = self.model_type
+        
+        
+        # check if there are initializers in input graph if using a local model
+        if local:
+            if check_onnx_clean(model_path):
+                raise ValueError("The ONNX model still has graph initializers in the input graph. Use `remove_initializer_from_input` to remove them.") 
+        else:
+            pass 
+
+        
+    def __repr__(self):
+        if self.local:
+            return f"Class to handle ONNX model locally stored at {self.model_path}"
+        else:
+            return f"Class to handle a {self.model_card['model_name']} from the PathML model zoo."
+    
+    def inference(self, image):
+        
+        # reshape the image
+        image = self.reshape(image) 
+        
+        # load fixed model 
+        onnx_model = onnx.load(self.model_path)
+        
+        # check tile dimensions match ONNX input dimensions 
+        input_node = onnx_model.graph.input
+        
+        dimensions = []
+        for input in input_node: 
+            if input.name == self.input_name: 
+                input_shape = input.type.tensor_type.shape.dim
+                for dim in input_shape:
+                    dimensions.append(dim.dim_value) 
+ 
+        assert image.shape[-1] == dimensions[-1] and image.shape[-2] == dimensions[-2], f'expecting tile shape of {dimensions[-2]} by {dimensions[-1]}, got {image.shape[-2]} by {image.shape[-1]}'
+                
+        # check onnx model
+        onnx.checker.check_model(onnx_model)
+        
+        # start an inference session
+        ort_sess = ort.InferenceSession(self.model_path)
+        
+        # create model output, returns a list 
+        model_output = ort_sess.run(None, {self.input_name: image.astype('f')}) 
+        
+        return model_output
+    
+    def F(self, image):
+        
+        # run inference function
+        prediction_map = self.inference(image) 
+        
+        # single task model
+        if len(prediction_map) == 1:
+            # return first and only prediction array in the list 
+            return prediction_map[0] 
+        
+        # multi task model
+        else:
+            # concatenate prediction results
+            # assumes that the tasks all output prediction arrays of same dimension on H and W
+            # To Do: figure out solution for way different tasks such as if a model does both segmentation and classification
+            result_array = np.concatenate(prediction_map, axis = 1)
+            return result_array 
+            
+    def apply(self, tile):
+        tile.image = self.F(tile.image)
+
+class HaloAIInference(Inference):
+    """Transformation to run inferrence on HALO AI ONNX model.
+    
+    Assumptions:
+        - Assumes that the ONNX model returns a tensor in which there is one prediction map for each class
+        - For example, if there are 5 classes, the ONNX model will output a (1, 5, Height, Weight) tensor
+        - If you select to argmax the classes, the class assumes a softmax or sigmoid has already been applied
+        - HaloAI ONNX models always have 20 class maps so you need to index into the first x maps if you have x classes
+    
+    
+    Args:
+        model_path (str): path to ONNX model w/o initializers,
+        num_classes (int): number of classes in the data, 
+        input_name (str): name of the input the ONNX model accepts
+    """ 
+    def __init__(self, model_path = None, input_name = 'data', num_classes = None, model_type = None, local = True): 
+        super().__init__(model_path, input_name, num_classes, model_type, local) 
+        
+        self.model_card['num_classes'] = self.num_classes
+        self.model_card['model_type'] = self.model_type
+        
+        
+    def __repr__(self):
+        return f"Class to handle HALO AI ONNX model locally stored at {self.model_path}"
+        
+    def F(self, image):
+        
+        prediction_map = self.inference(image)
+        
+        prediction_map = prediction_map[0][:, 0 : self.num_classes, :, :]
+        
+        return prediction_map
+    
+    def apply(self, tile):
+        tile.image = self.F(tile.image)
+        
+# class to handle remote onnx models 
+# ToDo create function to remove model after tiling is done would be a sep line in workflow
+class RemoteTestHoverNet(Inference):
+    """Transformation to run inferrence on ONNX model.
+    
+    Citation for model:
+    Pocock J, Graham S, Vu QD, Jahanifar M, Deshpande S, Hadjigeorghiou G, Shephard A, Bashir RM, Bilal M, Lu W, Epstein D. 
+    TIAToolbox as an end-to-end library for advanced tissue image analytics. Communications medicine. 2022 Sep 24;2(1):120.
+    
+    Args:
+        model_path (str): temp file name to download onnx from huggingface,
+        input_name (str): name of the input the ONNX model accepts
+    """ 
+    def __init__(self, model_path = 'temp.onnx', input_name = 'data', num_classes = 5, model_type = 'Segmentation', local = False):
+        super().__init__(model_path, input_name, num_classes, model_type, local)
+        
+        # specify URL of the model in PathML public repository
+        url = 'https://huggingface.co/pathml/test/resolve/main/hovernet_fast_tiatoolbox_fixed.onnx'
+        
+        # download model, save as temp.onnx 
+        with open(self.model_path, 'wb') as out_file:
+            content = requests.get(url, stream=True).content
+            out_file.write(content)
+        
+            
+        self.model_card['num_classes'] = self.num_classes
+        self.model_card['model_type'] = self.model_type
+        self.model_card['name'] = 'Tiabox HoverNet Test'
+        self.model_card['model_input_notes'] = 'Accepts tiles of 256 x 256' 
+        self.model_card['citation'] = 'Pocock J, Graham S, Vu QD, Jahanifar M, Deshpande S, Hadjigeorghiou G, Shephard A, Bashir RM, Bilal M, Lu W, Epstein D. TIAToolbox as an end-to-end library for advanced tissue image analytics. Communications medicine. 2022 Sep 24;2(1):120.'
+        
+        
+    def __repr__(self):
+        return "Class to handle remote TIAToolBox HoverNet test ONNX. See model card for citation."
+    
+    def apply(self, tile):
+        tile.image = self.F(tile.image)
+        
+    def remove(self):
+        # remove the temp.onnx model 
+        os.remove(self.model_path) 

--- a/pathml/inference/inference.py
+++ b/pathml/inference/inference.py
@@ -4,11 +4,14 @@ License: GNU GPL 2.0
 """
 
 import os
+
 import numpy as np
-import pathml.preprocessing.transforms as Transforms
 import onnx
 import onnxruntime
 import requests
+
+import pathml.preprocessing.transforms as Transforms
+
 
 
 def remove_initializer_from_input(model_path, new_path):

--- a/pathml/inference/inference.py
+++ b/pathml/inference/inference.py
@@ -4,24 +4,25 @@ License: GNU GPL 2.0
 """
 
 import os
-import numpy as np 
+import numpy as np
 import pathml.preprocessing.transforms as Transforms
 import onnx
-import onnxruntime 
-import requests 
+import onnxruntime
+import requests
+
 
 def remove_initializer_from_input(model_path, new_path):
     """Removes initializers from HaloAI ONNX models
     Taken from https://github.com/microsoft/onnxruntime/blob/main/tools/python/remove_initializer_from_input.py
-    
+
     Args:
         model_path (str): path to ONNX model,
         new_path (str): path to save adjusted model w/o initializers,
 
     Returns:
         ONNX model w/o initializers to run inference using PathML
-    """ 
-    
+    """
+
     model = onnx.load(model_path)
 
     inputs = model.graph.input
@@ -35,18 +36,18 @@ def remove_initializer_from_input(model_path, new_path):
 
     onnx.save(model, new_path)
 
-    
+
 def check_onnx_clean(model_path):
-    """Checks if the model has had it's initalizers removed from input graph. 
+    """Checks if the model has had it's initalizers removed from input graph.
     Adapted from from https://github.com/microsoft/onnxruntime/blob/main/tools/python/remove_initializer_from_input.py
-    
+
     Args:
         model_path (str): path to ONNX model,
 
     Returns:
-        Boolean if there are initializers in input graph. 
-    """ 
-    
+        Boolean if there are initializers in input graph.
+    """
+
     model = onnx.load(model_path)
 
     inputs = model.graph.input
@@ -56,75 +57,74 @@ def check_onnx_clean(model_path):
 
     for initializer in model.graph.initializer:
         if initializer.name in name_to_input:
-            return True 
+            return True
+
 
 # Base class
-# I think this should still inherit from Transforms to make the tiling easier/so we don't have to rewrite so much existing code 
+# I think this should still inherit from Transforms to make the tiling easier/so we don't have to rewrite so much existing code
 class InferenceBase(Transforms.Transform):
     """
     Base class for all ONNX Models.
     Each transform must operate on a Tile.
     """
-    
-    def __init__(self): 
+
+    def __init__(self):
         self.model_card = {
-            'name' : None, 
-            'num_classes' : None,
-            'model_type' : None, 
-            'notes' : None,  
-            'model_input_notes': None, 
-            'model_output_notes' : None,
-            'citation': None 
-        } 
+            "name": None,
+            "num_classes": None,
+            "model_type": None,
+            "notes": None,
+            "model_input_notes": None,
+            "model_output_notes": None,
+            "citation": None,
+        }
 
     def __repr__(self):
         return "Base class for all ONNX models"
-    
-    
+
     def get_model_card(self):
         return self.model_card
-    
+
     def set_name(self, name):
-        self.model_card['name'] = name  
-        
+        self.model_card["name"] = name
+
     def set_num_classes(self, num):
-        self.model_card['num_classes'] = num
-    
+        self.model_card["num_classes"] = num
+
     def set_model_type(self, model_type):
-        self.model_card['model_type'] = model_type
-        
+        self.model_card["model_type"] = model_type
+
     def set_notes(self, note):
-        self.model_card['notes'] = note 
-    
+        self.model_card["notes"] = note
+
     def set_model_input_notes(self, note):
-        self.model_card['model_input_notes'] = note
-    
+        self.model_card["model_input_notes"] = note
+
     def set_model_output_notes(self, note):
-        self.model_card['model_output_notes'] = note
-    
+        self.model_card["model_output_notes"] = note
+
     def set_citation(self, citation):
-        self.model_card['citation'] = citation  
-        
-    
+        self.model_card["citation"] = citation
+
     def reshape(self, image):
         """standard reshaping of tile image"""
-        # flip dimensions 
+        # flip dimensions
         # follows convention used here https://github.com/Dana-Farber-AIOS/pathml/blob/master/pathml/ml/dataset.py
-        
+
         if image.ndim == 3:
-            # swap axes from HWC to CHW 
+            # swap axes from HWC to CHW
             image = image.transpose(2, 0, 1)
-            # add a dimesion bc onnx models usually have batch size as first dim: e.g. (1, channel, height, width) 
-            image = np.expand_dims(image, axis = 0)
-            
-            return image 
+            # add a dimesion bc onnx models usually have batch size as first dim: e.g. (1, channel, height, width)
+            image = np.expand_dims(image, axis=0)
+
+            return image
         else:
             # in this case, we assume that we have XYZCT channel order
             # so we swap axes to TCZYX for batching
             # note we are not adding a dim here for batch bc we assume that subsetting will create a batch "placeholder" dim
             image = image.T
-            
-            return image 
+
+            return image
 
     def F(self, target):
         """functional implementation"""
@@ -133,179 +133,203 @@ class InferenceBase(Transforms.Transform):
     def apply(self, tile):
         """modify Tile object in-place"""
         raise NotImplementedError
-        
-# class to handle local onnx models 
+
+
+# class to handle local onnx models
 class Inference(InferenceBase):
     """Transformation to run inferrence on ONNX model.
-    
+
     Assumptions:
-        - The ONNX model has been cleaned by `remove_initializer_from_input` first 
-    
+        - The ONNX model has been cleaned by `remove_initializer_from_input` first
+
     Args:
         model_path (str): path to ONNX model w/o initializers,
         input_name (str): name of the input the ONNX model accepts
-    """ 
-    def __init__(self, model_path = None, input_name = 'data', num_classes = None, model_type = None, local = True):
-        super().__init__() 
-        
-        
-        self.input_name = input_name 
+    """
+
+    def __init__(
+        self,
+        model_path=None,
+        input_name="data",
+        num_classes=None,
+        model_type=None,
+        local=True,
+    ):
+        super().__init__()
+
+        self.input_name = input_name
         self.num_classes = num_classes
         self.model_type = model_type
         self.local = local
-        
+
         if self.local:
             # using a local onnx model
             self.model_path = model_path
-        else: 
+        else:
             # if using a model from the model zoo, set the local path to a temp file
-            self.model_path = 'temp.onnx' 
-           
+            self.model_path = "temp.onnx"
+
         # fill in parts of the model_card with the following info
-        self.model_card['num_classes'] = self.num_classes
-        self.model_card['model_type'] = self.model_type
-        
-        
+        self.model_card["num_classes"] = self.num_classes
+        self.model_card["model_type"] = self.model_type
+
         # check if there are initializers in input graph if using a local model
         if local:
             if check_onnx_clean(model_path):
-                raise ValueError("The ONNX model still has graph initializers in the input graph. Use `remove_initializer_from_input` to remove them.") 
+                raise ValueError(
+                    "The ONNX model still has graph initializers in the input graph. Use `remove_initializer_from_input` to remove them."
+                )
         else:
-            pass 
+            pass
 
-        
     def __repr__(self):
         if self.local:
             return f"Class to handle ONNX model locally stored at {self.model_path}"
         else:
             return f"Class to handle a {self.model_card['model_name']} from the PathML model zoo."
-    
+
     def inference(self, image):
-        
         # reshape the image
-        image = self.reshape(image) 
-        
-        # load fixed model 
+        image = self.reshape(image)
+
+        # load fixed model
         onnx_model = onnx.load(self.model_path)
-        
-        # check tile dimensions match ONNX input dimensions 
+
+        # check tile dimensions match ONNX input dimensions
         input_node = onnx_model.graph.input
-        
+
         dimensions = []
-        for input in input_node: 
-            if input.name == self.input_name: 
+        for input in input_node:
+            if input.name == self.input_name:
                 input_shape = input.type.tensor_type.shape.dim
                 for dim in input_shape:
-                    dimensions.append(dim.dim_value) 
- 
-        assert image.shape[-1] == dimensions[-1] and image.shape[-2] == dimensions[-2], f'expecting tile shape of {dimensions[-2]} by {dimensions[-1]}, got {image.shape[-2]} by {image.shape[-1]}'
-                
+                    dimensions.append(dim.dim_value)
+
+        assert (
+            image.shape[-1] == dimensions[-1] and image.shape[-2] == dimensions[-2]
+        ), f"expecting tile shape of {dimensions[-2]} by {dimensions[-1]}, got {image.shape[-2]} by {image.shape[-1]}"
+
         # check onnx model
         onnx.checker.check_model(onnx_model)
-        
+
         # start an inference session
         ort_sess = onnxruntime.InferenceSession(self.model_path)
-        
-        # create model output, returns a list 
-        model_output = ort_sess.run(None, {self.input_name: image.astype('f')}) 
-        
+
+        # create model output, returns a list
+        model_output = ort_sess.run(None, {self.input_name: image.astype("f")})
+
         return model_output
-    
+
     def F(self, image):
-        
         # run inference function
-        prediction_map = self.inference(image) 
-        
+        prediction_map = self.inference(image)
+
         # single task model
         if len(prediction_map) == 1:
-            # return first and only prediction array in the list 
-            return prediction_map[0] 
-        
+            # return first and only prediction array in the list
+            return prediction_map[0]
+
         # multi task model
         else:
             # concatenate prediction results
             # assumes that the tasks all output prediction arrays of same dimension on H and W
             # To Do: figure out solution for way different tasks such as if a model does both segmentation and classification
-            result_array = np.concatenate(prediction_map, axis = 1)
-            return result_array 
-            
+            result_array = np.concatenate(prediction_map, axis=1)
+            return result_array
+
     def apply(self, tile):
         tile.image = self.F(tile.image)
 
+
 class HaloAIInference(Inference):
     """Transformation to run inferrence on HALO AI ONNX model.
-    
+
     Assumptions:
         - Assumes that the ONNX model returns a tensor in which there is one prediction map for each class
         - For example, if there are 5 classes, the ONNX model will output a (1, 5, Height, Weight) tensor
         - If you select to argmax the classes, the class assumes a softmax or sigmoid has already been applied
         - HaloAI ONNX models always have 20 class maps so you need to index into the first x maps if you have x classes
-    
-    
+
+
     Args:
         model_path (str): path to ONNX model w/o initializers,
-        num_classes (int): number of classes in the data, 
+        num_classes (int): number of classes in the data,
         input_name (str): name of the input the ONNX model accepts
-    """ 
-    def __init__(self, model_path = None, input_name = 'data', num_classes = None, model_type = None, local = True): 
-        super().__init__(model_path, input_name, num_classes, model_type, local) 
-        
-        self.model_card['num_classes'] = self.num_classes
-        self.model_card['model_type'] = self.model_type
-        
-        
+    """
+
+    def __init__(
+        self,
+        model_path=None,
+        input_name="data",
+        num_classes=None,
+        model_type=None,
+        local=True,
+    ):
+        super().__init__(model_path, input_name, num_classes, model_type, local)
+
+        self.model_card["num_classes"] = self.num_classes
+        self.model_card["model_type"] = self.model_type
+
     def __repr__(self):
         return f"Class to handle HALO AI ONNX model locally stored at {self.model_path}"
-        
+
     def F(self, image):
-        
         prediction_map = self.inference(image)
-        
+
         prediction_map = prediction_map[0][:, 0 : self.num_classes, :, :]
-        
+
         return prediction_map
-    
+
     def apply(self, tile):
         tile.image = self.F(tile.image)
-        
-# class to handle remote onnx models 
+
+
+# class to handle remote onnx models
 # ToDo create function to remove model after tiling is done would be a sep line in workflow
 class RemoteTestHoverNet(Inference):
     """Transformation to run inferrence on ONNX model.
-    
+
     Citation for model:
-    Pocock J, Graham S, Vu QD, Jahanifar M, Deshpande S, Hadjigeorghiou G, Shephard A, Bashir RM, Bilal M, Lu W, Epstein D. 
+    Pocock J, Graham S, Vu QD, Jahanifar M, Deshpande S, Hadjigeorghiou G, Shephard A, Bashir RM, Bilal M, Lu W, Epstein D.
     TIAToolbox as an end-to-end library for advanced tissue image analytics. Communications medicine. 2022 Sep 24;2(1):120.
-    
+
     Args:
         model_path (str): temp file name to download onnx from huggingface,
         input_name (str): name of the input the ONNX model accepts
-    """ 
-    def __init__(self, model_path = 'temp.onnx', input_name = 'data', num_classes = 5, model_type = 'Segmentation', local = False):
+    """
+
+    def __init__(
+        self,
+        model_path="temp.onnx",
+        input_name="data",
+        num_classes=5,
+        model_type="Segmentation",
+        local=False,
+    ):
         super().__init__(model_path, input_name, num_classes, model_type, local)
-        
+
         # specify URL of the model in PathML public repository
-        url = 'https://huggingface.co/pathml/test/resolve/main/hovernet_fast_tiatoolbox_fixed.onnx'
-        
-        # download model, save as temp.onnx 
-        with open(self.model_path, 'wb') as out_file:
+        url = "https://huggingface.co/pathml/test/resolve/main/hovernet_fast_tiatoolbox_fixed.onnx"
+
+        # download model, save as temp.onnx
+        with open(self.model_path, "wb") as out_file:
             content = requests.get(url, stream=True).content
             out_file.write(content)
-        
-            
-        self.model_card['num_classes'] = self.num_classes
-        self.model_card['model_type'] = self.model_type
-        self.model_card['name'] = 'Tiabox HoverNet Test'
-        self.model_card['model_input_notes'] = 'Accepts tiles of 256 x 256' 
-        self.model_card['citation'] = 'Pocock J, Graham S, Vu QD, Jahanifar M, Deshpande S, Hadjigeorghiou G, Shephard A, Bashir RM, Bilal M, Lu W, Epstein D. TIAToolbox as an end-to-end library for advanced tissue image analytics. Communications medicine. 2022 Sep 24;2(1):120.'
-        
-        
+
+        self.model_card["num_classes"] = self.num_classes
+        self.model_card["model_type"] = self.model_type
+        self.model_card["name"] = "Tiabox HoverNet Test"
+        self.model_card["model_input_notes"] = "Accepts tiles of 256 x 256"
+        self.model_card[
+            "citation"
+        ] = "Pocock J, Graham S, Vu QD, Jahanifar M, Deshpande S, Hadjigeorghiou G, Shephard A, Bashir RM, Bilal M, Lu W, Epstein D. TIAToolbox as an end-to-end library for advanced tissue image analytics. Communications medicine. 2022 Sep 24;2(1):120."
+
     def __repr__(self):
         return "Class to handle remote TIAToolBox HoverNet test ONNX. See model card for citation."
-    
+
     def apply(self, tile):
         tile.image = self.F(tile.image)
-        
+
     def remove(self):
-        # remove the temp.onnx model 
-        os.remove(self.model_path) 
+        # remove the temp.onnx model
+        os.remove(self.model_path)

--- a/pathml/inference/inference.py
+++ b/pathml/inference/inference.py
@@ -5,12 +5,9 @@ License: GNU GPL 2.0
 
 import os
 import numpy as np 
-from pathml.core import SlideData, Tile
-from pathml.preprocessing import Pipeline
 import pathml.preprocessing.transforms as Transforms
 import onnx
-import onnxruntime as ort 
-import pathml 
+import onnxruntime 
 import requests 
 
 def remove_initializer_from_input(model_path, new_path):
@@ -207,7 +204,7 @@ class Inference(InferenceBase):
         onnx.checker.check_model(onnx_model)
         
         # start an inference session
-        ort_sess = ort.InferenceSession(self.model_path)
+        ort_sess = onnxruntime.InferenceSession(self.model_path)
         
         # create model output, returns a list 
         model_output = ort_sess.run(None, {self.input_name: image.astype('f')}) 

--- a/pathml/inference/inference.py
+++ b/pathml/inference/inference.py
@@ -13,7 +13,6 @@ import requests
 import pathml.preprocessing.transforms as Transforms
 
 
-
 def remove_initializer_from_input(model_path, new_path):
     """Removes initializers from HaloAI ONNX models
     Taken from https://github.com/microsoft/onnxruntime/blob/main/tools/python/remove_initializer_from_input.py

--- a/pathml/inference/inference.py
+++ b/pathml/inference/inference.py
@@ -11,7 +11,7 @@ import pathml.preprocessing.transforms as Transforms
 import onnx
 import onnxruntime as ort 
 import pathml 
-
+import requests 
 
 def remove_initializer_from_input(model_path, new_path):
     """Removes initializers from HaloAI ONNX models

--- a/tests/inference_tests/test_inference.py
+++ b/tests/inference_tests/test_inference.py
@@ -127,7 +127,7 @@ def test_InferenceBase():
 
 
 def test_Inference(tileHE):
-    new_path = "../testdata/random_model.onnx"
+    new_path = "tests/testdata/random_model.onnx"
 
     inference = Inference(
         model_path=new_path, input_name="data", num_classes=1, model_type="segmentation"
@@ -139,7 +139,7 @@ def test_Inference(tileHE):
 
 
 def test_HaloAIInference(tileHE):
-    new_path = "../testdata/random_model.onnx"
+    new_path = "tests/testdata/random_model.onnx"
 
     inference = HaloAIInference(
         model_path=new_path, input_name="data", num_classes=1, model_type="segmentation"
@@ -152,7 +152,7 @@ def test_HaloAIInference(tileHE):
 def test_RemoteTestHoverNet():
     inference = RemoteTestHoverNet()
 
-    wsi = SlideData("../testdata/small_HE.svs")
+    wsi = SlideData("tests/testdata/small_HE.svs")
 
     tiles = wsi.generate_tiles(shape=(256, 256), pad=False)
     a = 0

--- a/tests/inference_tests/test_inference.py
+++ b/tests/inference_tests/test_inference.py
@@ -13,7 +13,6 @@ from pathml.inference import (
 )
 
 
-
 def test_remove_initializer_from_input():
     # Create a temporary ONNX model file
     model_path = "test_model.onnx"

--- a/tests/inference_tests/test_inference.py
+++ b/tests/inference_tests/test_inference.py
@@ -3,6 +3,7 @@ import os
 import numpy as np
 import onnx
 
+from pathml.core import SlideData
 from pathml.inference import (
     HaloAIInference,
     Inference,
@@ -126,7 +127,7 @@ def test_InferenceBase():
 
 
 def test_Inference(tileHE):
-    new_path = "../testdata/andom_model.onnx"
+    new_path = "../testdata/random_model.onnx"
 
     inference = Inference(
         model_path=new_path, input_name="data", num_classes=1, model_type="segmentation"
@@ -138,7 +139,7 @@ def test_Inference(tileHE):
 
 
 def test_HaloAIInference(tileHE):
-    new_path = "../testdata/andom_model.onnx"
+    new_path = "../testdata/random_model.onnx"
 
     inference = HaloAIInference(
         model_path=new_path, input_name="data", num_classes=1, model_type="segmentation"
@@ -148,11 +149,22 @@ def test_HaloAIInference(tileHE):
     assert np.array_equal(tileHE.image, inference.F(orig_im))
 
 
-def test_RemoteTestHoverNet(tileHE):
+def test_RemoteTestHoverNet():
     inference = RemoteTestHoverNet()
 
-    orig_im = tileHE.image
-    inference.apply(tileHE)
-    assert np.array_equal(tileHE.image, inference.F(orig_im))
+    wsi = SlideData("../testdata/small_HE.svs")
+
+    tiles = wsi.generate_tiles(shape=(256, 256), pad=False)
+    a = 0
+    test_tile = None
+
+    while a == 0:
+        for tile in tiles:
+            test_tile = tile
+            a += 1
+
+    orig_im = test_tile.image
+    inference.apply(test_tile)
+    assert np.array_equal(test_tile.image, inference.F(orig_im))
 
     inference.remove()

--- a/tests/inference_tests/test_inference.py
+++ b/tests/inference_tests/test_inference.py
@@ -1,14 +1,16 @@
 import os
 import numpy as np
 import onnx
+import onnxruntime as ort
+import pytest
 
-from pathml.inference import (   
+from pathml.inference import (
     remove_initializer_from_input,
-    check_onnx_clean, 
-    InferenceBase, 
-    Inference, 
-    HaloAIInference, 
-    RemoteTestHoverNet
+    check_onnx_clean,
+    InferenceBase,
+    Inference,
+    HaloAIInference,
+    RemoteTestHoverNet,
 )
 
 
@@ -43,12 +45,13 @@ def test_remove_initializer_from_input():
     # Assert that the initializer has been removed from the new model
     new_model = onnx.load(new_model_path)
     input_names = [input.name for input in new_model.graph.input]
-    assert initializer.name not in input_names 
+    assert initializer.name not in input_names
 
     # Clean up the temporary files
     os.remove(model_path)
     os.remove(new_model_path)
-    
+
+
 def test_check_onnx_clean():
     # Create a temporary ONNX model file
     model_path = "test_model.onnx"
@@ -76,66 +79,81 @@ def test_check_onnx_clean():
     if check_onnx_clean(model_path):
         pass
     else:
-        raise ValueError('check_onnx_clean function is not working') 
+        raise ValueError("check_onnx_clean function is not working")
 
     # Clean up the temporary files
     os.remove(model_path)
-    
-def test_InferenceBase(): 
-    
+
+
+def test_InferenceBase():
     # initialize InferenceBase
     test = InferenceBase()
-    
-    # test setter functions 
-    test.set_name('name') 
-    
-    test.set_num_classes('num_classes')
-    
-    test.set_model_type('model_type')
-        
-    test.set_notes('notes')
-    
-    test.set_model_input_notes('model_input_notes')
-    
-    test.set_model_output_notes('model_output_notes')
-    
-    test.set_citation('citation')
-    
+
+    # test setter functions
+    test.set_name("name")
+
+    test.set_num_classes("num_classes")
+
+    test.set_model_type("model_type")
+
+    test.set_notes("notes")
+
+    test.set_model_input_notes("model_input_notes")
+
+    test.set_model_output_notes("model_output_notes")
+
+    test.set_citation("citation")
+
     for key in test.model_card:
         assert key == test.model_card[key], f"function for {key} is not working"
-    
-    # test reshape function 
-    random = np.random.rand(1,2,3)
-    assert test.reshape(random).shape == (1, 3, 1, 2), "reshape function is not working on 3d arrays" 
-    
-    random = np.random.rand(1,2,3,4,5)
-    assert test.reshape(random).shape == (5,4,3,2,1), "reshape function is not working on 5d arrays" 
-    
-def test_Inference(tileHE): 
-    
-    new_path = '../random_model.onnx'
-    
-    inference = Inference(model_path = new_path, input_name = 'data', num_classes = 1, model_type = 'segmentation')
-    
+
+    # test reshape function
+    random = np.random.rand(1, 2, 3)
+    assert test.reshape(random).shape == (
+        1,
+        3,
+        1,
+        2,
+    ), "reshape function is not working on 3d arrays"
+
+    random = np.random.rand(1, 2, 3, 4, 5)
+    assert test.reshape(random).shape == (
+        5,
+        4,
+        3,
+        2,
+        1,
+    ), "reshape function is not working on 5d arrays"
+
+
+def test_Inference(tileHE):
+    new_path = "../random_model.onnx"
+
+    inference = Inference(
+        model_path=new_path, input_name="data", num_classes=1, model_type="segmentation"
+    )
+
     orig_im = tileHE.image
     inference.apply(tileHE)
     assert np.array_equal(tileHE.image, inference.F(orig_im))
-    
-def test_HaloAIInference(tileHE): 
 
-    new_path = '../random_model.onnx'
 
-    inference = HaloAIInference(model_path = new_path, input_name = 'data', num_classes = 1, model_type = 'segmentation')
+def test_HaloAIInference(tileHE):
+    new_path = "../random_model.onnx"
+
+    inference = HaloAIInference(
+        model_path=new_path, input_name="data", num_classes=1, model_type="segmentation"
+    )
     orig_im = tileHE.image
     inference.apply(tileHE)
     assert np.array_equal(tileHE.image, inference.F(orig_im))
 
-def test_RemoteTestHoverNet(tileHE): 
 
+def test_RemoteTestHoverNet(tileHE):
     inference = RemoteTestHoverNet()
 
     orig_im = tileHE.image
     inference.apply(tileHE)
     assert np.array_equal(tileHE.image, inference.F(orig_im))
-    
-    inference.remove() 
+
+    inference.remove()

--- a/tests/inference_tests/test_inference.py
+++ b/tests/inference_tests/test_inference.py
@@ -4,7 +4,14 @@ import onnx
 import onnxruntime as ort 
 import pytest 
 
-from pathml.inference import *
+from pathml.inference import (   
+    remove_initializer_from_input,
+    check_onnx_clean, 
+    InferenceBase, 
+    Inference, 
+    HaloAIInference, 
+    RemoteTestHoverNet
+)
 
 
 def test_remove_initializer_from_input():

--- a/tests/inference_tests/test_inference.py
+++ b/tests/inference_tests/test_inference.py
@@ -126,7 +126,7 @@ def test_InferenceBase():
 
 
 def test_Inference(tileHE):
-    new_path = "../random_model.onnx"
+    new_path = "../testdata/andom_model.onnx"
 
     inference = Inference(
         model_path=new_path, input_name="data", num_classes=1, model_type="segmentation"
@@ -138,7 +138,7 @@ def test_Inference(tileHE):
 
 
 def test_HaloAIInference(tileHE):
-    new_path = "../random_model.onnx"
+    new_path = "../testdata/andom_model.onnx"
 
     inference = HaloAIInference(
         model_path=new_path, input_name="data", num_classes=1, model_type="segmentation"

--- a/tests/inference_tests/test_inference.py
+++ b/tests/inference_tests/test_inference.py
@@ -1,8 +1,6 @@
 import os
 import numpy as np
 import onnx
-import onnxruntime as ort 
-import pytest 
 
 from pathml.inference import (   
     remove_initializer_from_input,

--- a/tests/inference_tests/test_inference.py
+++ b/tests/inference_tests/test_inference.py
@@ -1,0 +1,136 @@
+import os
+import numpy as np
+import onnx
+import onnxruntime as ort 
+import pytest 
+
+from pathml.inference import *
+
+
+def test_remove_initializer_from_input():
+    # Create a temporary ONNX model file
+    model_path = "test_model.onnx"
+    # temp_file = tempfile.NamedTemporaryFile(delete=False)
+    # temp_file.close()
+
+    # Create a sample ONNX model with initializer and graph input
+    model = onnx.ModelProto()
+    model.ir_version = 4
+
+    # Add inputs to the graph
+    input_1 = model.graph.input.add()
+    input_1.name = "input_1"
+
+    input_2 = model.graph.input.add()
+    input_2.name = "input_2"
+
+    # Add an initializer that matches one of the inputs
+    initializer = model.graph.initializer.add()
+    initializer.name = "input_2"
+
+    # Save the model to a file
+    onnx.save(model, model_path)
+
+    # Call the function to remove initializers
+    new_model_path = "new_model.onnx"
+    remove_initializer_from_input(model_path, new_model_path)
+
+    # Assert that the initializer has been removed from the new model
+    new_model = onnx.load(new_model_path)
+    input_names = [input.name for input in new_model.graph.input]
+    assert initializer.name not in input_names 
+
+    # Clean up the temporary files
+    os.remove(model_path)
+    os.remove(new_model_path)
+    
+def test_check_onnx_clean():
+    # Create a temporary ONNX model file
+    model_path = "test_model.onnx"
+    # temp_file = tempfile.NamedTemporaryFile(delete=False)
+    # temp_file.close()
+
+    # Create a sample ONNX model with initializer and graph input
+    model = onnx.ModelProto()
+    model.ir_version = 4
+
+    # Add inputs to the graph
+    input_1 = model.graph.input.add()
+    input_1.name = "input_1"
+
+    input_2 = model.graph.input.add()
+    input_2.name = "input_2"
+
+    # Add an initializer that matches one of the inputs
+    initializer = model.graph.initializer.add()
+    initializer.name = "input_2"
+
+    # Save the model to a file
+    onnx.save(model, model_path)
+
+    if check_onnx_clean(model_path):
+        pass
+    else:
+        raise ValueError('check_onnx_clean function is not working') 
+
+    # Clean up the temporary files
+    os.remove(model_path)
+    
+def test_InferenceBase(): 
+    
+    # initialize InferenceBase
+    test = InferenceBase()
+    
+    # test setter functions 
+    test.set_name('name') 
+    
+    test.set_num_classes('num_classes')
+    
+    test.set_model_type('model_type')
+        
+    test.set_notes('notes')
+    
+    test.set_model_input_notes('model_input_notes')
+    
+    test.set_model_output_notes('model_output_notes')
+    
+    test.set_citation('citation')
+    
+    for key in test.model_card:
+        assert key == test.model_card[key], f"function for {key} is not working"
+    
+    # test reshape function 
+    random = np.random.rand(1,2,3)
+    assert test.reshape(random).shape == (1, 3, 1, 2), "reshape function is not working on 3d arrays" 
+    
+    random = np.random.rand(1,2,3,4,5)
+    assert test.reshape(random).shape == (5,4,3,2,1), "reshape function is not working on 5d arrays" 
+    
+def test_Inference(tileHE): 
+    
+    new_path = '../random_model.onnx'
+    
+    inference = Inference(model_path = new_path, input_name = 'data', num_classes = 1, model_type = 'segmentation')
+    
+    orig_im = tileHE.image
+    inference.apply(tileHE)
+    assert np.array_equal(tileHE.image, inference.F(orig_im))
+    
+def test_HaloAIInference(tileHE): 
+
+    new_path = '../random_model.onnx'
+
+    inference = HaloAIInference(model_path = new_path, input_name = 'data', num_classes = 1, model_type = 'segmentation')
+    orig_im = tileHE.image
+    inference.apply(tileHE)
+    assert np.array_equal(tileHE.image, inference.F(orig_im))
+
+def test_RemoteTestHoverNet(tileHE): 
+
+    inference = RemoteTestHoverNet()
+
+    orig_im = tileHE.image
+    inference.apply(tileHE)
+    assert np.array_equal(tileHE.image, inference.F(orig_im))
+    
+    inference.remove() 

--- a/tests/inference_tests/test_inference.py
+++ b/tests/inference_tests/test_inference.py
@@ -1,17 +1,17 @@
 import os
+
 import numpy as np
 import onnx
-import onnxruntime as ort
-import pytest
 
 from pathml.inference import (
-    remove_initializer_from_input,
-    check_onnx_clean,
-    InferenceBase,
-    Inference,
     HaloAIInference,
+    Inference,
+    InferenceBase,
     RemoteTestHoverNet,
+    check_onnx_clean,
+    remove_initializer_from_input,
 )
+
 
 
 def test_remove_initializer_from_input():

--- a/tests/testdata/random_model.onnx
+++ b/tests/testdata/random_model.onnx
@@ -1,0 +1,23 @@
+pytorch2.0.0:ÿ
+‘
+data
+conv.weight
+	conv.bias3
+/conv/Conv"Conv*
+	dilations@@ *
+group *
+kernel_shape@@ *
+pads@@@@ *
+strides@@ 	torch_jit*…Bconv.weightJlÚã>½¦=ãŒ*½…&¬=R¼N¹½Qp€=R·.¾p&r½Dè2>Ì4Å=d2#½İS½é‡?>˜ä<}2r½ù).<|V~;Â¾±ı@½HE8¾@Ó>ÅLô½/¶/>Ëñ~½Æ…Ë¼s.¾*B	conv.biasJ œA¾Z 
+data
+
+
+
+ô
+ôb
+3
+
+
+
+ô
+ôB


### PR DESCRIPTION
Adding `inference` subpackage.

This subpackage will enable inference via ONNX models.

Tests are in the`inference_tests` folder. 
A dummy ONNX CNN is in `tests/testdata` for the tests.

Updates to dependencies: 
- numpy==1.22.4 # orig = 1.19.5
- pytest==7.4.0 # orig = 6.2.5
- deepcell==0.12.7 # orig = 0.11.0
- pandas==1.5.2 # orig no req