### PR TITLE
Update readthedocs-requirements.txt

### DIFF
--- a/docs/readthedocs-requirements.txt
+++ b/docs/readthedocs-requirements.txt
@@ -1,8 +1,7 @@
-sphinx==4.3.2
-nbsphinx==0.8.8
+sphinx==7.0.0
+nbsphinx==0.9.3
 nbsphinx-link==1.3.0
-sphinx-rtd-theme==1.0.0
-sphinx-autoapi==1.8.4
+sphinx-rtd-theme==1.3.0
+sphinx-autoapi==3.0.0
 ipython==8.10.0
-sphinx-copybutton==0.4.0
-
+sphinx-copybutton==0.5.2


### PR DESCRIPTION
Updated readthedocs requirements to fix the following error:

```Extension error (autoapi.extension):
Handler <function run_autoapi at 0x7f297c65e310> for event 'builder-inited' threw an exception (exception: 'Module' object has no attribute 'doc')
make: *** [Makefile:20: html] Error 2
Error: Process completed with exit code 2.```