### PR TITLE
Updating pydicom to 2.4.5

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -13,10 +13,10 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
  
-      - name: Set Up Python 3.9
+      - name: Set Up Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
  
       - name: Install Build Tool
         run: pip install --upgrade build

--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -18,7 +18,7 @@ jobs:
       # Limit concurrency to reduce memory pressure
       max-parallel: 2
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.10", "3.11", "3.12"]
     timeout-minutes: 60
 
     steps:

--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.10", "3.11", "3.12"]
         
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [ "3.9", "3.10"]
+        python-version: ["3.10", "3.11", "3.12"]
     timeout-minutes: 120
 
     steps:

--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,7 @@ dependencies:
     - openjdk<=18.0.0
     - h5py==3.10.0
     - dask<=2023.12.1
-    - pydicom==2.4.4
+    - pydicom==2.4.5
     - pytest==7.4.3
     - pre-commit<=3.6.0
     - coverage==7.2.7

--- a/requirements/environment_docker.yml
+++ b/requirements/environment_docker.yml
@@ -5,7 +5,7 @@ channels:
     - pytorch
 
 dependencies:
-    - python>=3.9,<3.11
+    - python>=3.10,<=3.12
     - pip==25.0.1
     - numpy==1.23.5
     - scipy<=1.11.4
@@ -14,7 +14,7 @@ dependencies:
     - openjdk<=18.0.0
     - h5py==3.10.0
     - dask<=2023.12.1
-    - pydicom==2.4.4
+    - pydicom==2.4.5
     - coverage<7.3
     - pytest==7.4.3 
     - pre-commit<=3.6.0

--- a/requirements/environment_mac.yml
+++ b/requirements/environment_mac.yml
@@ -5,7 +5,7 @@ channels:
     - pytorch
 
 dependencies:
-    - python<=3.10
+    - python>=3.10,<=3.12
     - pip==23.3.2
     - numpy==1.23.5
     - python-javabridge==4.0.3
@@ -15,7 +15,7 @@ dependencies:
     - openjdk<=18.0.0
     - h5py==3.10.0
     - dask<=2023.12.1
-    - pydicom==2.4.4
+    - pydicom==2.4.5
     - pytest==7.4.3 
     - pre-commit<=3.6.0
     - coverage==7.2.7

--- a/requirements/environment_test.yml
+++ b/requirements/environment_test.yml
@@ -5,7 +5,7 @@ channels:
     - pytorch
 
 dependencies:
-    - python<=3.10
+    - python>=3.10,<=3.12
     - pip==25.0.1
     - numpy==1.23.5
     - scipy<=1.11.4
@@ -15,7 +15,7 @@ dependencies:
     # - pytorch==2.8.0
     - h5py==3.10.0
     - dask<=2023.12.1
-    - pydicom==2.4.4
+    - pydicom==2.4.5
     - pytest==7.4.3
     - pre-commit<=3.6.0
     - coverage==7.2.7

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setuptools.setup(
         "jpype1==1.4.1",
         "tqdm==4.66.3",
         "anndata<=0.10.3",
-        "pydicom==2.4.4",
+        "pydicom==2.4.5",
     ],
     classifiers=[
         "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",


### PR DESCRIPTION
**Updating pydicom to 2.4.5**

Security issue flagged in https://github.com/Dana-Farber-AIOS/pathml/security/dependabot/27

Update means PathML will not be compatible with Python 3.9 anymore.

Adding Python 3.11 and 3.12 to test suite.